### PR TITLE
Updates to Improve Advertising-Spend-ROI-Prediction

### DIFF
--- a/Advertising-Spend-ROI-Prediction/README.md
+++ b/Advertising-Spend-ROI-Prediction/README.md
@@ -33,11 +33,10 @@ https://user-images.githubusercontent.com/1723932/175127637-9149b9f3-e12a-4acd-a
 
 ## Setup
 
----
 ```sql
-  USE ROLE ACCOUNTADMIN;
+  USE ROLE SYSADMIN;
 ```
----
+
 ### **Step 1** -- Create Tables, Load Data and Setup Stages
 
 An example database, tables, stages, and file formats will be configured and created as you're executing the (Snowpark_For_Python.ipynb) notebook.
@@ -46,9 +45,8 @@ These stages will be configured to use data hosted on a publicly accessible S3 b
 
 For the Streamlit application, you will need to create a table BUDGET_ALLOCATIONS_AND_ROI that holds the last six months of budget allocations and ROI.
 
----
 ```sql
-  CREATE or REPLACE TABLE BUDGET_ALLOCATIONS_AND_ROI (
+  CREATE or REPLACE TABLE SNOWPARK_ROI_DEMO.AD_DATA.BUDGET_ALLOCATIONS_AND_ROI (
     MONTH varchar(30),
     SEARCHENGINE integer,
     SOCIALMEDIA integer,
@@ -66,7 +64,7 @@ For the Streamlit application, you will need to create a table BUDGET_ALLOCATION
   ('May',95,95,10,95,6.246),
   ('June',35,50,35,85,8.22);
 ```
----
+
 ## Notebook and Streamlit App
 
 ### **Step 1** -- Clone Repo

--- a/Advertising-Spend-ROI-Prediction/README.md
+++ b/Advertising-Spend-ROI-Prediction/README.md
@@ -1,3 +1,4 @@
+
 # Advertising Spend and ROI Prediction
 
 This is the same demo that was presented during the [Snowflake Summit Opening Keynote](https://events.snowflake.com/summit/agenda/session/849836). It is built using Snowpark For Python and Streamlit. For questions and feedback, please reach out to <dash.desai@snowflake.com>.
@@ -27,61 +28,26 @@ https://user-images.githubusercontent.com/1723932/175127637-9149b9f3-e12a-4acd-a
     * Click on the **Billing** on the left side panel
     * Click on [Terms and Billing](https://app.snowflake.com/terms-and-billing)
     * Read and accept terms to continue with the workshop
-  * As ACCOUNTADMIN role
+  * As SYSADMIN role
     * Create a [Warehouse](https://docs.snowflake.com/en/sql-reference/sql/create-warehouse.html), a [Database](https://docs.snowflake.com/en/sql-reference/sql/create-database.html) and a [Schema](https://docs.snowflake.com/en/sql-reference/sql/create-schema.html)
 
 ## Setup
 
-  ```sql
+---
+```sql
   USE ROLE ACCOUNTADMIN;
-  ```
-
+```
+---
 ### **Step 1** -- Create Tables, Load Data and Setup Stages
 
-* Create table CAMPAIGN_SPEND from data hosted on publicly accessible S3 bucket
+An example database, tables, stages, and file formats will be configured and created as you're executing the (Snowpark_For_Python.ipynb) notebook.
 
-  ```sql
-  CREATE or REPLACE file format csvformat
-    skip_header = 1
-    type = 'CSV';
+These stages will be configured to use data hosted on a publicly accessible S3 bucket.
 
-  CREATE or REPLACE stage campaign_data_stage
-    file_format = csvformat
-    url = 's3://sfquickstarts/Summit 2022 Keynote Demo/campaign_spend/';
+For the Streamlit application, you will need to create a table BUDGET_ALLOCATIONS_AND_ROI that holds the last six months of budget allocations and ROI.
 
-  CREATE or REPLACE TABLE CAMPAIGN_SPEND (
-    CAMPAIGN VARCHAR(60),
-    CHANNEL VARCHAR(60),
-    DATE DATE,
-    TOTAL_CLICKS NUMBER(38,0),
-    TOTAL_COST NUMBER(38,0),
-    ADS_SERVED NUMBER(38,0)
-  );
-
-  COPY into CAMPAIGN_SPEND
-    from @campaign_data_stage;
-  ```
-
-* Create table MONTHLY_REVENUE from data hosted on publicly accessible S3 bucket
-
-  ```sql
-  CREATE or REPLACE stage monthly_revenue_data_stage
-    file_format = csvformat
-    url = 's3://sfquickstarts/Summit 2022 Keynote Demo/monthly_revenue/';
-
-  CREATE or REPLACE TABLE MONTHLY_REVENUE (
-    YEAR NUMBER(38,0),
-    MONTH NUMBER(38,0),
-    REVENUE FLOAT
-  );
-
-  COPY into MONTHLY_REVENUE
-    from @monthly_revenue_data_stage;
-  ```
-
-* Create table BUDGET_ALLOCATIONS_AND_ROI that holds the last six months of budget allocations and ROI
-
-  ```sql
+---
+```sql
   CREATE or REPLACE TABLE BUDGET_ALLOCATIONS_AND_ROI (
     MONTH varchar(30),
     SEARCHENGINE integer,
@@ -99,16 +65,8 @@ https://user-images.githubusercontent.com/1723932/175127637-9149b9f3-e12a-4acd-a
   ('April',25,80,40,90,13.23),
   ('May',95,95,10,95,6.246),
   ('June',35,50,35,85,8.22);
-  ```
-
-* Create stages required for Stored Procedures, UDFs, and saving model files
-
-  ```sql
-  CREATE OR REPLACE STAGE dash_sprocs;
-  CREATE OR REPLACE STAGE dash_models;
-  CREATE OR REPLACE STAGE dash_udfs;
-  ```
-
+```
+---
 ## Notebook and Streamlit App
 
 ### **Step 1** -- Clone Repo

--- a/Advertising-Spend-ROI-Prediction/Snowpark_For_Python.ipynb
+++ b/Advertising-Spend-ROI-Prediction/Snowpark_For_Python.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 1,
    "id": "persistent-reasoning",
    "metadata": {
     "papermill": {
@@ -85,8 +85,6 @@
    },
    "outputs": [],
    "source": [
-    "# Snowpark for Python\n",
-    "# Misc\n",
     "import json\n",
     "import logging\n",
     "\n",
@@ -117,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 2,
    "id": "rotary-dairy",
    "metadata": {
     "papermill": {
@@ -129,27 +127,113 @@
     },
     "tags": []
    },
+   "outputs": [],
+   "source": [
+    "# Create Snowflake Session object\n",
+    "connection_parameters = json.load(open('connection.json'))\n",
+    "session = Session.builder.configs(connection_parameters).create()\n",
+    "session.sql_simplifier_enabled = True"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "b6929c9f",
+   "metadata": {},
+   "source": [
+    "Create objects to use for this demonstration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "83aad8aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Row(status='Stage area PYTHON_CODE successfully created.')]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "session.sql(\n",
+    "    \"\"\"CREATE WAREHOUSE IF NOT EXISTS SNOWPARK_DEMO_WH \n",
+    "           WITH WAREHOUSE_SIZE = 'MEDIUM' \n",
+    "                WAREHOUSE_TYPE = 'STANDARD' \n",
+    "                AUTO_SUSPEND = 60 \n",
+    "                AUTO_RESUME = TRUE \n",
+    "                INITIALLY_SUSPENDED = TRUE;\"\"\"\n",
+    ").collect()\n",
+    "session.sql(\"CREATE DATABASE IF NOT EXISTS SNOWPARK_ROI_DEMO;\").collect()\n",
+    "session.sql(\"DROP SCHEMA IF EXISTS SNOWPARK_ROI_DEMO.PUBLIC;\").collect()\n",
+    "session.sql(\"CREATE SCHEMA IF NOT EXISTS SNOWPARK_ROI_DEMO.AD_DATA;\").collect()\n",
+    "session.sql(\n",
+    "    \"\"\"CREATE FILE FORMAT IF NOT EXISTS SNOWPARK_ROI_DEMO.AD_DATA.CSVFORMAT \n",
+    "           SKIP_HEADER = 1 \n",
+    "           TYPE = 'CSV';\"\"\"\n",
+    ").collect()\n",
+    "session.sql(\n",
+    "    \"\"\"CREATE STAGE IF NOT EXISTS SNOWPARK_ROI_DEMO.AD_DATA.CAMPAIGN_DATA_STAGE \n",
+    "           FILE_FORMAT = SNOWPARK_ROI_DEMO.AD_DATA.CSVFORMAT  \n",
+    "           URL = 's3://sfquickstarts/Summit 2022 Keynote Demo/campaign_spend/';\"\"\"\n",
+    ").collect()\n",
+    "session.sql(\n",
+    "    \"\"\"CREATE STAGE IF NOT EXISTS SNOWPARK_ROI_DEMO.AD_DATA.MONTHLY_REVENUE_DATA_STAGE \n",
+    "           FILE_FORMAT = SNOWPARK_ROI_DEMO.AD_DATA.CSVFORMAT  \n",
+    "           URL = 's3://sfquickstarts/Summit 2022 Keynote Demo/monthly_revenue/';\"\"\"\n",
+    ").collect()\n",
+    "session.sql(\"CREATE OR REPLACE STAGE SNOWPARK_ROI_DEMO.AD_DATA.PYTHON_MODELS\").collect()\n",
+    "session.sql(\"CREATE OR REPLACE STAGE SNOWPARK_ROI_DEMO.AD_DATA.PYTHON_CODE\").collect()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "8086a1b4",
+   "metadata": {},
+   "source": [
+    "Change the current context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "44e80c04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "session.use_warehouse(\"SNOWPARK_DEMO_WH\")\n",
+    "session.use_database(\"SNOWPARK_ROI_DEMO\")\n",
+    "session.use_schema(\"AD_DATA\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "df81161f",
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "User                        : DASHDESAI\n",
-      "Role                        : ACCOUNTADMIN\n",
-      "Database                    : DASH_DB\n",
-      "Schema                      : DASH_SCHEMA\n",
-      "Warehouse                   : DASH_L\n",
-      "Snowflake version           : 7.2.0\n",
-      "Snowpark for Python version : 1.0.0\n"
+      "User                        : TWHITE\n",
+      "Role                        : SYSADMIN\n",
+      "Database                    : SNOWPARK_ROI_DEMO\n",
+      "Schema                      : AD_DATA\n",
+      "Warehouse                   : SNOWPARK_DEMO_WH\n",
+      "Snowflake version           : 7.15.0\n",
+      "Snowpark for Python version : 1.4.0\n"
      ]
     }
    ],
    "source": [
-    "# Create Snowflake Session object\n",
-    "connection_parameters = json.load(open('connection.json'))\n",
-    "session = Session.builder.configs(connection_parameters).create()\n",
-    "session.sql_simplifier_enabled = True\n",
-    "\n",
     "snowflake_environment = session.sql('select current_user(), current_role(), current_database(), current_schema(), current_version(), current_warehouse()').collect()\n",
     "snowpark_version = VERSION\n",
     "\n",
@@ -161,6 +245,36 @@
     "print('Warehouse                   : {}'.format(snowflake_environment[0][5]))\n",
     "print('Snowflake version           : {}'.format(snowflake_environment[0][4]))\n",
     "print('Snowpark for Python version : {}.{}.{}'.format(snowpark_version[0],snowpark_version[1],snowpark_version[2]))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "0ecf9f18",
+   "metadata": {},
+   "source": [
+    "View the files in the external stage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c91c525c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Row(name='s3://sfquickstarts/Summit 2022 Keynote Demo/campaign_spend/campaign_spend.csv', size=13684943, md5='1d87f70421662a7666d3918b16b81daa', last_modified='Fri, 5 Aug 2022 20:22:18 GMT')]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "session.sql(\"LS @CAMPAIGN_DATA_STAGE\").collect()"
    ]
   },
   {
@@ -182,8 +296,77 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "dfe69d8a",
+   "metadata": {},
+   "source": [
+    "Query and preview the CSV file in the stage."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 7,
+   "id": "971953f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------------------------------------------------------------\n",
+      "|\"CAMPAIGN\"              |\"CHANNEL\"      |\"DATE\"      |\"TOTAL_CLICKS\"  |\"TOTAL_COST\"  |\"ADS_SERVED\"  |\n",
+      "------------------------------------------------------------------------------------------------------\n",
+      "|winter_sports           |video          |2012-06-03  |213             |1762          |426           |\n",
+      "|sports_across_cultures  |video          |2012-06-02  |87              |678           |157           |\n",
+      "|building_community      |search_engine  |2012-06-03  |66              |471           |134           |\n",
+      "|world_series            |social_media   |2017-12-28  |72              |591           |149           |\n",
+      "|winter_sports           |email          |2018-02-09  |252             |1841          |473           |\n",
+      "|spring_break            |video          |2017-11-14  |162             |1155          |304           |\n",
+      "|nba_finals              |email          |2017-11-22  |68              |480           |134           |\n",
+      "|winter_sports           |social_media   |2018-03-10  |227             |1797          |454           |\n",
+      "|spring_break            |search_engine  |2017-08-30  |150             |1226          |302           |\n",
+      "|uefa                    |video          |2017-09-30  |81              |701           |168           |\n",
+      "------------------------------------------------------------------------------------------------------\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = session.sql(\n",
+    "    \"\"\"SELECT $1::VARCHAR(60) AS CAMPAIGN, \n",
+    "              $2::VARCHAR(60) AS CHANNEL, \n",
+    "              $3::DATE AS DATE, \n",
+    "              $4::NUMBER(38, 0) AS TOTAL_CLICKS, \n",
+    "              $5::NUMBER(38, 0) AS TOTAL_COST, \n",
+    "              $6::NUMBER(38, 0) AS ADS_SERVED \n",
+    "       FROM @CAMPAIGN_DATA_STAGE\"\"\")\n",
+    "\n",
+    "df.show()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "ef7b09f5",
+   "metadata": {},
+   "source": [
+    "Write this DataFrame to a Snowflake table named `CAMPAIGN_SPEND`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "784e8a62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.write.save_as_table(\"CAMPAIGN_SPEND\", mode=\"overwrite\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "id": "d80bed43",
    "metadata": {},
    "outputs": [
@@ -193,7 +376,7 @@
        "{'queries': ['SELECT  *  FROM (campaign_spend)'], 'post_actions': []}"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 10,
    "id": "e7129be1",
    "metadata": {},
    "outputs": [
@@ -243,10 +426,10 @@
     {
      "data": {
       "text/plain": [
-       "[QueryRecord(query_id='01a9f037-0602-77fb-001e-248300d4a3e6', sql_text='SELECT  *  FROM campaign_spend LIMIT 10')]"
+       "[QueryRecord(query_id='01ac2ca3-0b04-804d-0001-ce160094a316', sql_text='SELECT  *  FROM campaign_spend LIMIT 10')]"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 11,
    "id": "laden-contest",
    "metadata": {
     "papermill": {
@@ -330,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 12,
    "id": "2f8a63e7",
    "metadata": {},
    "outputs": [
@@ -387,7 +570,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 13,
+   "id": "005ec504",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = session.sql(\n",
+    "    \"\"\"SELECT $1::NUMBER(38, 0) AS YEAR, \n",
+    "              $2::NUMBER(38, 0) AS MONTH, \n",
+    "              $3::FLOAT AS REVENUE\n",
+    "       FROM @MONTHLY_REVENUE_DATA_STAGE\"\"\")\n",
+    "\n",
+    "df.write.save_as_table(\"MONTHLY_REVENUE\", mode=\"overwrite\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "013b2276",
    "metadata": {},
    "outputs": [
@@ -437,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 15,
    "id": "1d49b236",
    "metadata": {},
    "outputs": [
@@ -480,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 16,
    "id": "f9c78499",
    "metadata": {},
    "outputs": [
@@ -491,7 +690,7 @@
       "---------DATAFRAME EXECUTION PLAN----------\n",
       "Query List:\n",
       "1.\n",
-      "SELECT  *  FROM (( SELECT \"YEAR\" AS \"YEAR\", \"MONTH\" AS \"MONTH\", \"SEARCH_ENGINE\" AS \"SEARCH_ENGINE\", \"SOCIAL_MEDIA\" AS \"SOCIAL_MEDIA\", \"VIDEO\" AS \"VIDEO\", \"EMAIL\" AS \"EMAIL\" FROM ( SELECT \"YEAR\", \"MONTH\", \"'search_engine'\" AS \"SEARCH_ENGINE\", \"'social_media'\" AS \"SOCIAL_MEDIA\", \"'video'\" AS \"VIDEO\", \"'email'\" AS \"EMAIL\" FROM ( SELECT  *  FROM ( SELECT  *  FROM ( SELECT  *  FROM ( SELECT \"YEAR(DATE)\" AS \"YEAR\", \"MONTH(DATE)\" AS \"MONTH\", \"CHANNEL\", \"TOTAL_COST\" FROM ( SELECT year(\"DATE\") AS \"YEAR(DATE)\", month(\"DATE\") AS \"MONTH(DATE)\", \"CHANNEL\", sum(\"TOTAL_COST\") AS \"TOTAL_COST\" FROM ( SELECT  *  FROM campaign_spend) GROUP BY year(\"DATE\"), month(\"DATE\"), \"CHANNEL\")) ORDER BY \"YEAR\" ASC NULLS FIRST, \"MONTH\" ASC NULLS FIRST) PIVOT (sum(\"TOTAL_COST\") FOR \"CHANNEL\" IN ('search_engine', 'social_media', 'video', 'email'))) ORDER BY \"YEAR\" ASC NULLS FIRST, \"MONTH\" ASC NULLS FIRST))) AS SNOWPARK_TEMP_TABLE_972QWTQC8Y INNER JOIN ( SELECT \"YEAR\" AS \"YEAR\", \"MONTH\" AS \"MONTH\", \"REVENUE\" AS \"REVENUE\" FROM ( SELECT \"YEAR\", \"MONTH\", \"SUM(REVENUE)\" AS \"REVENUE\" FROM ( SELECT  *  FROM ( SELECT \"YEAR\", \"MONTH\", sum(\"REVENUE\") AS \"SUM(REVENUE)\" FROM ( SELECT  *  FROM monthly_revenue) GROUP BY \"YEAR\", \"MONTH\") ORDER BY \"YEAR\" ASC NULLS FIRST, \"MONTH\" ASC NULLS FIRST))) AS SNOWPARK_TEMP_TABLE_6GP6KAHYR6 USING (YEAR, MONTH))\n",
+      "SELECT  *  FROM (( SELECT \"YEAR\" AS \"YEAR\", \"MONTH\" AS \"MONTH\", \"SEARCH_ENGINE\" AS \"SEARCH_ENGINE\", \"SOCIAL_MEDIA\" AS \"SOCIAL_MEDIA\", \"VIDEO\" AS \"VIDEO\", \"EMAIL\" AS \"EMAIL\" FROM ( SELECT \"YEAR\", \"MONTH\", \"'search_engine'\" AS \"SEARCH_ENGINE\", \"'social_media'\" AS \"SOCIAL_MEDIA\", \"'video'\" AS \"VIDEO\", \"'email'\" AS \"EMAIL\" FROM ( SELECT  *  FROM ( SELECT  *  FROM ( SELECT \"YEAR(DATE)\" AS \"YEAR\", \"MONTH(DATE)\" AS \"MONTH\", \"CHANNEL\", \"TOTAL_COST\" FROM ( SELECT year(\"DATE\") AS \"YEAR(DATE)\", month(\"DATE\") AS \"MONTH(DATE)\", \"CHANNEL\", sum(\"TOTAL_COST\") AS \"TOTAL_COST\" FROM ( SELECT  *  FROM campaign_spend) GROUP BY year(\"DATE\"), month(\"DATE\"), \"CHANNEL\")) ORDER BY \"YEAR\" ASC NULLS FIRST, \"MONTH\" ASC NULLS FIRST) PIVOT (sum(\"TOTAL_COST\") FOR \"CHANNEL\" IN ('search_engine', 'social_media', 'video', 'email'))) ORDER BY \"YEAR\" ASC NULLS FIRST, \"MONTH\" ASC NULLS FIRST)) AS SNOWPARK_LEFT INNER JOIN ( SELECT \"YEAR\" AS \"YEAR\", \"MONTH\" AS \"MONTH\", \"REVENUE\" AS \"REVENUE\" FROM ( SELECT \"YEAR\", \"MONTH\", \"SUM(REVENUE)\" AS \"REVENUE\" FROM ( SELECT \"YEAR\", \"MONTH\", sum(\"REVENUE\") AS \"SUM(REVENUE)\" FROM ( SELECT  *  FROM monthly_revenue) GROUP BY \"YEAR\", \"MONTH\") ORDER BY \"YEAR\" ASC NULLS FIRST, \"MONTH\" ASC NULLS FIRST)) AS SNOWPARK_RIGHT USING (YEAR, MONTH))\n",
       "Logical Execution Plan:\n",
       "GlobalStats:\n",
       "    partitionsTotal=2\n",
@@ -504,10 +703,10 @@
       "1:3                    ->Pivot  'search_engine', 'social_media', 'video', 'email'  \n",
       "1:4                         ->Sort  EXTRACT(year from CAMPAIGN_SPEND.DATE) ASC NULLS FIRST, EXTRACT(month from CAMPAIGN_SPEND.DATE) ASC NULLS FIRST  \n",
       "1:5                              ->Aggregate  aggExprs: [SUM(CAMPAIGN_SPEND.TOTAL_COST)], groupKeys: [EXTRACT(year from CAMPAIGN_SPEND.DATE), EXTRACT(month from CAMPAIGN_SPEND.DATE), CAMPAIGN_SPEND.CHANNEL]  \n",
-      "1:6                                   ->TableScan  DASH_DB.DASH_SCHEMA.CAMPAIGN_SPEND  CHANNEL, DATE, TOTAL_COST  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=1728512}\n",
+      "1:6                                   ->TableScan  SNOWPARK_ROI_DEMO.AD_DATA.CAMPAIGN_SPEND  CHANNEL, DATE, TOTAL_COST  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=1728512}\n",
       "1:7               ->Sort  MONTHLY_REVENUE.YEAR ASC NULLS FIRST, MONTHLY_REVENUE.MONTH ASC NULLS FIRST  \n",
       "1:8                    ->JoinFilter  joinKey: (EXTRACT(month from CAMPAIGN_SPEND.DATE) = MONTHLY_REVENUE.MONTH) AND (EXTRACT(year from CAMPAIGN_SPEND.DATE) = MONTHLY_REVENUE.YEAR)  \n",
-      "1:9                         ->TableScan  DASH_DB.DASH_SCHEMA.MONTHLY_REVENUE  YEAR, MONTH, REVENUE  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=2560}\n",
+      "1:9                         ->TableScan  SNOWPARK_ROI_DEMO.AD_DATA.MONTHLY_REVENUE  YEAR, MONTH, REVENUE  {partitionsTotal=1, partitionsAssigned=1, bytesAssigned=2560}\n",
       "\n",
       "--------------------------------------------\n"
      ]
@@ -538,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 17,
    "id": "678e4646",
    "metadata": {},
    "outputs": [
@@ -610,7 +809,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 18,
    "id": "caring-weight",
    "metadata": {
     "papermill": {
@@ -681,7 +880,7 @@
     "            model_output_dir = '/tmp'\n",
     "            model_file = os.path.join(model_output_dir, 'model.joblib')\n",
     "            dump(model, model_file)\n",
-    "            session.file.put(model_file,\"@dash_models\",overwrite=True)\n",
+    "            session.file.put(model_file,\"@PYTHON_MODELS\",overwrite=True)\n",
     "            model_saved = True\n",
     "\n",
     "    # Return model R2 score on train and test data\n",
@@ -704,21 +903,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 19,
    "id": "924c4f5f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'R2 score on Train': 0.9954552822793986,\n",
+       "{'R2 score on Train': 0.9951556820022874,\n",
        " 'R2 threshold on Train': 0.85,\n",
-       " 'R2 score on Test': 0.881797109776519,\n",
+       " 'R2 score on Test': 0.9661098174787692,\n",
        " 'R2 threshold on Test': 0.85,\n",
        " 'Model saved': False}"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -754,17 +953,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 20,
    "id": "630975b1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<snowflake.snowpark.stored_procedure.StoredProcedure at 0x7fc060d07af0>"
+       "<snowflake.snowpark.stored_procedure.StoredProcedure at 0x10a81bb20>"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -775,7 +974,7 @@
     "    name=\"train_revenue_prediction_model\",\n",
     "    packages=['snowflake-snowpark-python','scikit-learn','joblib'],\n",
     "    is_permanent=True,\n",
-    "    stage_location=\"@dash_sprocs\",\n",
+    "    stage_location=\"@PYTHON_CODE\",\n",
     "    replace=True)"
    ]
   },
@@ -799,7 +998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 21,
    "id": "a8846d95",
    "metadata": {},
    "outputs": [
@@ -809,8 +1008,8 @@
      "text": [
       "{\n",
       "  \"Model saved\": true,\n",
-      "  \"R2 score on Test\": 0.8817971097765088,\n",
-      "  \"R2 score on Train\": 0.9954552822793987,\n",
+      "  \"R2 score on Test\": 0.9661098174787647,\n",
+      "  \"R2 score on Train\": 0.9951556820022874,\n",
       "  \"R2 threshold on Test\": 0.85,\n",
       "  \"R2 threshold on Train\": 0.85\n",
       "}\n"
@@ -857,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 22,
    "id": "4a2c9a07",
    "metadata": {},
    "outputs": [],
@@ -866,10 +1065,10 @@
     "session.clear_packages()\n",
     "\n",
     "# Add trained model and Python packages from Snowflake Anaconda channel available on the server-side as UDF dependencies\n",
-    "session.add_import('@dash_models/model.joblib.gz')\n",
+    "session.add_import('@PYTHON_MODELS/model.joblib.gz')\n",
     "session.add_packages('pandas','joblib','scikit-learn==1.1.1')\n",
     "\n",
-    "@udf(name='predict_roi',session=session,replace=True,is_permanent=True,stage_location='@dash_udfs')\n",
+    "@udf(name='predict_roi',session=session,replace=True,is_permanent=True,stage_location='@PYTHON_CODE')\n",
     "def predict_roi(budget_allocations: list) -> float:\n",
     "    import sys\n",
     "\n",
@@ -921,7 +1120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 23,
    "id": "d922f065",
    "metadata": {},
    "outputs": [
@@ -932,9 +1131,9 @@
       "-----------------------------------------------------------------------------\n",
       "|\"SEARCH_ENGINE\"  |\"SOCIAL_MEDIA\"  |\"VIDEO\"  |\"EMAIL\"  |\"PREDICTED_ROI\"     |\n",
       "-----------------------------------------------------------------------------\n",
-      "|500000           |500000          |500000   |500000   |3179613.166194177   |\n",
-      "|8500             |9500            |2000     |500      |189866.83304722887  |\n",
-      "|250000           |250000          |200000   |450000   |4072491.441668165   |\n",
+      "|8500             |9500            |2000     |500      |233784.8440105631   |\n",
+      "|500000           |500000          |500000   |500000   |3178590.4246200803  |\n",
+      "|250000           |250000          |200000   |450000   |333166.0182221518   |\n",
       "-----------------------------------------------------------------------------\n",
       "\n"
      ]
@@ -972,7 +1171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 24,
    "id": "9b938b6e",
    "metadata": {},
    "outputs": [],
@@ -984,7 +1183,7 @@
     "from snowflake.snowpark.types import PandasDataFrame, PandasSeries\n",
     "\n",
     "# Add trained model and Python packages from Snowflake Anaconda channel available on the server-side as UDF dependencies\n",
-    "session.add_import('@dash_models/model.joblib.gz')\n",
+    "session.add_import('@PYTHON_MODELS/model.joblib.gz')\n",
     "session.add_packages('pandas','joblib','scikit-learn','cachetools')\n",
     "\n",
     "@cachetools.cached(cache={})\n",
@@ -1002,7 +1201,7 @@
     "            m = joblib.load(file)\n",
     "            return m\n",
     "\n",
-    "@udf(name='batch_predict_roi',session=session,replace=True,is_permanent=True,stage_location='@dash_udfs')\n",
+    "@udf(name='batch_predict_roi',session=session,replace=True,is_permanent=True,stage_location='@PYTHON_CODE')\n",
     "def batch_predict_roi(budget_allocations_df: PandasDataFrame[int, int, int, int]) -> PandasSeries[float]:\n",
     "    import sklearn\n",
     "    budget_allocations_df.columns = ['SEARCH_ENGINE','SOCIAL_MEDIA','VIDEO','EMAIL']\n",
@@ -1025,7 +1224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 25,
    "id": "57045fca",
    "metadata": {},
    "outputs": [
@@ -1036,9 +1235,9 @@
       "-----------------------------------------------------------------------------\n",
       "|\"SEARCH_ENGINE\"  |\"SOCIAL_MEDIA\"  |\"VIDEO\"  |\"EMAIL\"  |\"PREDICTED_ROI\"     |\n",
       "-----------------------------------------------------------------------------\n",
-      "|250000           |250000          |200000   |450000   |4072491.441668165   |\n",
-      "|8500             |9500            |2000     |500      |189866.83304722887  |\n",
-      "|500000           |500000          |500000   |500000   |3179613.166194177   |\n",
+      "|8500             |9500            |2000     |500      |233784.8440105631   |\n",
+      "|500000           |500000          |500000   |500000   |3178590.4246200803  |\n",
+      "|250000           |250000          |200000   |450000   |333166.0182221518   |\n",
       "-----------------------------------------------------------------------------\n",
       "\n"
      ]
@@ -1089,7 +1288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 26,
    "id": "113d10cb",
    "metadata": {},
    "outputs": [],
@@ -1152,17 +1351,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 27,
    "id": "36c2e3fc",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<snowflake.snowpark.stored_procedure.StoredProcedure at 0x7fc060d19eb0>"
+       "<snowflake.snowpark.stored_procedure.StoredProcedure at 0x10a815cd0>"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1173,7 +1372,7 @@
     "    name=\"data_pipeline_feature_engineering\",\n",
     "    packages=['snowflake-snowpark-python'],\n",
     "    is_permanent=True,\n",
-    "    stage_location=\"@dash_sprocs\",\n",
+    "    stage_location=\"@PYTHON_CODE\",\n",
     "    replace=True)"
    ]
   },
@@ -1188,7 +1387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 28,
    "id": "7d3c17d0",
    "metadata": {},
    "outputs": [
@@ -1215,7 +1414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 33,
    "id": "8d357da9",
    "metadata": {},
    "outputs": [
@@ -1225,7 +1424,7 @@
        "[Row(status='Task DATA_PIPELINE_FEATURE_ENGINEERING_TASK successfully created.')]"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1233,7 +1432,7 @@
    "source": [
     "create_data_pipeline_feature_engineering_task = \"\"\"\n",
     "CREATE OR REPLACE TASK data_pipeline_feature_engineering_task\n",
-    "    WAREHOUSE = 'DASH_L'\n",
+    "    WAREHOUSE = 'SNOWPARK_DEMO_WH'\n",
     "    SCHEDULE  = '1 MINUTE'\n",
     "AS\n",
     "    CALL data_pipeline_feature_engineering()\n",
@@ -1252,7 +1451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 34,
    "id": "ed96cd51",
    "metadata": {},
    "outputs": [
@@ -1262,7 +1461,7 @@
        "[Row(status='Task MODEL_TRAINING_TASK successfully created.')]"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1270,7 +1469,7 @@
    "source": [
     "create_model_training_task = \"\"\"\n",
     "CREATE OR REPLACE TASK model_training_task\n",
-    "    WAREHOUSE = 'DASH_L'\n",
+    "    WAREHOUSE = 'SNOWPARK_DEMO_WH'\n",
     "    AFTER data_pipeline_feature_engineering_task\n",
     "AS\n",
     "    CALL train_revenue_prediction_model('MARKETING_BUDGETS_FEATURES',10,2,0.85,0.85,True)\n",
@@ -1289,7 +1488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 35,
    "id": "adc7ba32",
    "metadata": {},
    "outputs": [
@@ -1299,7 +1498,7 @@
        "[Row(status='Statement executed successfully.')]"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1320,7 +1519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 37,
    "id": "f872226f",
    "metadata": {},
    "outputs": [
@@ -1330,7 +1529,7 @@
        "[Row(status='Statement executed successfully.')]"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1366,7 +1565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.8.16"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
These updates include the creation of objects in the notebook, minor updates to the Streamlit app, and changes to the README file.

- I modified the notebook to create and use dependent objects. This has streamlined the process of using the notebook and reduced the need for additional steps. As part of this update, I trimmed the README file to remove references to objects needing to be created as a prerequisite.

- I have added object context to the Streamlit app. In addition, I have removed the experimental_memo usage to be replaced with [`cache_data`](https://docs.streamlit.io/library/api-reference/performance/st.cache_data). 

- I updated the README file to include fully qualified object names with object creation for use with the Streamlit app. 

Overall, these updates should represent a significant improvement to the functionality and usability of this example.